### PR TITLE
update: actions/checkout@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         ruby-version: [2.7, 3.0, 3.1, head]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem "rake", "~> 13.0"
 gem "test-unit", "~> 3.0"
 
 gem "simplecov", "~> 0.21.2"
+
+gem "json", ">= 2.7.2"

--- a/perfect_toml.gemspec
+++ b/perfect_toml.gemspec
@@ -31,5 +31,4 @@ END
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency 'ostruct'
 end

--- a/perfect_toml.gemspec
+++ b/perfect_toml.gemspec
@@ -31,4 +31,5 @@ END
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.add_dependency 'ostruct'
 end


### PR DESCRIPTION
Due to the end of support for Node.js 16, I would like to update the actions to use Node.js 20.

see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/