### PR TITLE
Run toml-test with "ruby --disble-gems"

### DIFF
--- a/tool/decoder.rb
+++ b/tool/decoder.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env -S ruby --disable-gems
 
 require_relative "../lib/perfect_toml"
 require "json"

--- a/tool/encoder.rb
+++ b/tool/encoder.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env -S ruby --disable-gems
 
 require_relative "../lib/perfect_toml"
 require "json"


### PR DESCRIPTION
This speeds up the rest runs by quite a bit by making the Ruby interpreter start faster. Rubygems aren't used for these commands.

Before:

	toml-test ./tool/decoder.rb  50.37s user 11.82s system 1554% cpu 4.000 total
	toml-test ./tool/encoder.rb -encoder  17.88s user 4.17s system 1519% cpu 1.451 total

After:

	toml-test ./tool/decoder.rb  8.97s user 8.86s system 1515% cpu 1.177 total
	toml-test ./tool/encoder.rb -encoder  3.62s user 3.17s system 1477% cpu 0.460 total