### PR TITLE
Raise ParseError for invalid string escapes

### DIFF
--- a/lib/perfect_toml.rb
+++ b/lib/perfect_toml.rb
@@ -327,8 +327,8 @@ module PerfectTOML
       @root_node = @topic_node = Node.new(1, nil)
 
       @re_escape_char = version == :TOML_1_0_0 ?
-        /([btnmfr"\\])|u([0-9A-Fa-f]{4})|U([0-9A-Fa-f]{8})/ :
-        /([btnmfre"\\])|x([0-9A-Fa-f]{2})|u([0-9A-Fa-f]{4})|U([0-9A-Fa-f]{8})/
+        /([btnfr"\\])|u([0-9A-Fa-f]{4})|U([0-9A-Fa-f]{8})/ :
+        /([btnfre"\\])|x([0-9A-Fa-f]{2})|u([0-9A-Fa-f]{4})|U([0-9A-Fa-f]{8})/
       @re_multiline_basic_string = version == :TOML_1_0_0 ?
         /[^\x00-\x08\x0b\x0c\x0e-\x1f\x7f"\\]*/ :
         /([^\x00-\x08\x0b-\x1f\x7f"\\]|\r\n)*/
@@ -412,7 +412,16 @@ module PerfectTOML
     def parse_escape_char
       if @s.skip(/\\/)
         if @s.skip(@re_escape_char)
-          @s[1] ? ESCAPE_CHARS[@s[1]] : (@s[2] || @s[3] || @s[4]).hex.chr("UTF-8")
+          if @s[1]
+            ESCAPE_CHARS[@s[1]]
+          else
+            code = (@s[2] || @s[3] || @s[4]).hex
+            begin
+              code.chr("UTF-8")
+            rescue RangeError
+              error "invalid Unicode scalar value in string: U+%04X" % code
+            end
+          end
         else
           unterminated_string_error if @s.eos?
           error "invalid escape character in string: #{ @s.peek(1).dump }"

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -60,6 +60,24 @@ a = "\e"
       END
     end
 
+    assert_parse_error("invalid escape character in string: \"m\" at line 1 column 7") do
+      PerfectTOML.parse(<<-'END')
+a = "\m"
+      END
+    end
+
+    assert_parse_error("invalid Unicode scalar value in string: U+D800 at line 1 column 12") do
+      PerfectTOML.parse(<<-'END')
+a = "\uD800"
+      END
+    end
+
+    assert_parse_error("invalid Unicode scalar value in string: U+110000 at line 1 column 16") do
+      PerfectTOML.parse(<<-'END')
+a = "\U00110000"
+      END
+    end
+
     assert_parse_error("invalid character in string: \"\\x00\" at line 1 column 31") do
       PerfectTOML.parse(<<-END)
 a = "raw control character -> \0"


### PR DESCRIPTION
Two invalid escape inputs raised low-level exceptions instead of the documented PerfectTOML::ParseError:

- \m (and \<other-non-escape>) crashed with TypeError because a stray 'm' was left in the escape-char character class but has no mapping.
- \uXXXX / \UXXXXXXXX outside the Unicode scalar range (surrogates and > U+10FFFF) crashed with RangeError from Integer#chr.

Drop the stray 'm' from the regex, and let Integer#chr("UTF-8") decide validity, converting its RangeError into a ParseError. Per the TOML spec these escapes must be valid Unicode scalar values.