### PR TITLE
Reject date literals with a sign

### DIFF
--- a/lib/perfect_toml.rb
+++ b/lib/perfect_toml.rb
@@ -575,7 +575,7 @@ module PerfectTOML
         @s.skip(/""/) ? parse_multiline_basic_string : parse_basic_string
       when @s.skip(/'/)
         @s.skip(/''/) ? parse_multiline_literal_string : parse_literal_string
-      when len = @s.skip(/(-?\d{4})-(\d{2})-(\d{2})(?:[tT ](\d{2}):(\d{2})(?::(\d{2}(?:\.\d+)?))?([zZ]|[-+]\d{2}:\d{2})?)?/)
+      when len = @s.skip(/(\d{4})-(\d{2})-(\d{2})(?:[tT ](\d{2}):(\d{2})(?::(\d{2}(?:\.\d+)?))?([zZ]|[-+]\d{2}:\d{2})?)?/)
         parse_datetime(len)
       when len = @s.skip(/(\d{2}):(\d{2})(?::(\d{2}(?:\.\d+)?))?/)
         parse_time(len)

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -142,4 +142,21 @@ wrong = 25:00:00
       END
     end
   end
+
+  def test_year_must_be_four_digits
+    # TOML requires dates to follow RFC 3339, whose grammar defines
+    # `date-fullyear = 4DIGIT`. The year is therefore exactly 4 digits
+    # with no sign, so neither a leading sign nor a 5-digit year is allowed.
+    assert_parse_error("unexpected identifier found: \"001-01-01\" at line 1 column 11") do
+      PerfectTOML.parse(<<-'END')
+wrong = -0001-01-01
+      END
+    end
+
+    assert_parse_error("unexpected identifier found: \"-01-01\" at line 1 column 14") do
+      PerfectTOML.parse(<<-'END')
+wrong = 10000-01-01
+      END
+    end
+  end
 end


### PR DESCRIPTION
TOML requires dates to follow RFC 3339, whose grammar defines `date-fullyear = 4DIGIT`: the year is exactly four digits with no sign. But the date regexp accepted an optional leading '-', so "-0001-01-01" parsed as a date and was even mis-rendered as "-001-01-01". Drop the optional sign so such input raises a ParseError.

The added test also guards the upper bound (a 5-digit year such as "10000-01-01" must be rejected too).